### PR TITLE
fix: normalize unsupported types to strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+* Fix Android crash by normalizing broadcast intent data
+
 ## 0.1.0
 
 Android integration complete:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_broadcasts
 description: A plugin for sending and receiving broadcasts with Android intents and iOS notifications.
-version: 0.2.0
+version: 0.3.0
 author: Kevin Latusinski <me@kevlatus.de>
 repository: https://github.com/kevlatus/flutter_broadcasts
 


### PR DESCRIPTION
`StandardMessageCodec` type used by Flutter engine for passing data to the Flutter layer supports only specific types. This commit converts unsupported types to strings to avoid Android level crashes.