### PR TITLE
fix: prevent creating a new stream for each subscriber to messages

### DIFF
--- a/lib/src/receiver.dart
+++ b/lib/src/receiver.dart
@@ -32,7 +32,7 @@ class BroadcastReceiver {
   bool get isListening => _subscription != null;
 
   /// A stream of matching messages received from the native platform.
-  Stream<BroadcastMessage> get messages => _messages.stream.asBroadcastStream();
+  Stream<BroadcastMessage> get messages => _messages.stream;
 
   /// Starts listening for messages on this [BroadcastReceiver].
   ///


### PR DESCRIPTION
asBroadcastStream at this point creates a new stream for each subscriber, eventually causing memory leaks because the underlying subscription of a new broadcast stream is never closed. Since _messages is already a StreamController.broadcast(), multiple subscribers are possible anyways.

For more information, see https://github.com/dart-lang/sdk/issues/26686