### PR TITLE
Android 14 Support (#1)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,13 +25,13 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 26
     }
 }
 

--- a/lib/src/receiver.dart
+++ b/lib/src/receiver.dart
@@ -20,11 +20,12 @@ class BroadcastReceiver {
   final List<String> names;
 
   StreamSubscription? _subscription;
+  final bool exported;
 
   /// Creates a new [BroadcastReceiver], which subscribes to the given [names].
   ///
   /// At least one name needs to be provided.
-  BroadcastReceiver({required this.names})
+  BroadcastReceiver({required this.names, this.exported = false})
       : assert(names.length > 0),
         _id = ++_index;
 
@@ -63,6 +64,7 @@ class BroadcastReceiver {
   Map<String, dynamic> toMap() => <String, dynamic>{
         'id': _id,
         'names': names,
+        'exported': exported ? 1 : 0,
       };
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_broadcasts
 description: A plugin for sending and receiving broadcasts with Android intents and iOS notifications.
-version: 0.4.0
+version: 0.4.1
 repository: https://github.com/kevlatus/flutter_broadcasts
 
 environment:


### PR DESCRIPTION
Added support for Android 14 allowing for `RECEIVER_EXPORTED` / `RECEIVER_NOT_EXPORTED` for the receiver.

This changes `minSdkVersion` to `26`, though.

Also updated `compileSdkVersion` to `34`.

NOTE: default for `exported` is `false`.