### PR TITLE
Update FlutterBroadcastsPlugin.kt

### DIFF
--- a/android/src/main/kotlin/de/kevlatus/flutter_broadcasts/FlutterBroadcastsPlugin.kt
+++ b/android/src/main/kotlin/de/kevlatus/flutter_broadcasts/FlutterBroadcastsPlugin.kt
@@ -46,7 +46,7 @@ class CustomBroadcastReceiver(
     }
 
     fun start(context: Context) {
-        context.registerReceiver(this, intentFilter)
+        context.registerReceiver(this, intentFilter, Context.RECEIVER_NOT_EXPORTED)
         Log.d(TAG, "starting to listen for broadcasts: " + names.joinToString(";"))
     }
 


### PR DESCRIPTION
As android 14 changed the broadcast register function and now its necessary to use the RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED flag when registering the BroadcastReceiver.