### PR TITLE
 feat: support Android 13+ ability to choose listen or not to broadcasts from other apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ First install the package via [pub.dev](https://pub.dev/packages/flutter_broadca
 ```dart
 BroadcastReceiver receiver = BroadcastReceiver(
   names: <String>["de.kevlatus.broadcast"],
+  listenToBroadcastsFromOtherApps: false,
 );
 receiver.messages.listen(print);
 receiver.start();

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,12 +25,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
+        compileSdk 33
         minSdkVersion 24
     }
 }

--- a/android/src/main/kotlin/de/kevlatus/flutter_broadcasts/FlutterBroadcastsPlugin.kt
+++ b/android/src/main/kotlin/de/kevlatus/flutter_broadcasts/FlutterBroadcastsPlugin.kt
@@ -50,9 +50,9 @@ class CustomBroadcastReceiver(
     fun start(context: Context) {
         if (Build.VERSION.SDK_INT >= 33) {
             val receiverFlags = if (listenToBroadcastsFromOtherApps) {
-                ContextCompat.RECEIVER_EXPORTED
+                Context.RECEIVER_EXPORTED
             } else {
-                ContextCompat.RECEIVER_NOT_EXPORTED
+                Context.RECEIVER_NOT_EXPORTED
             }
             context.registerReceiver(this, intentFilter, receiverFlags)
         } else {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -36,8 +36,8 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "de.kevlatus.flutter_broadcasts_example"
         minSdkVersion 24
-        targetSdkVersion 33
-        compileSdkVersion 31
+        targetSdkVersion 34
+        compileSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,6 +16,7 @@ class _MyAppState extends State<MyApp> {
     names: <String>[
       "de.kevlatus.flutter_broadcasts_example.demo_action",
     ],
+    listenToBroadcastsFromOtherApps: false,
   );
 
   @override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,7 +16,6 @@ class _MyAppState extends State<MyApp> {
     names: <String>[
       "de.kevlatus.flutter_broadcasts_example.demo_action",
     ],
-    listenToBroadcastsFromOtherApps: false,
   );
 
   @override

--- a/lib/src/receiver.dart
+++ b/lib/src/receiver.dart
@@ -19,12 +19,20 @@ class BroadcastReceiver {
   /// See [BroadcastMessage.name] for more details.
   final List<String> names;
 
+  /// Allow receiver to listen to broadcasts from other apps
+  ///
+  /// Android specific. Requires SDK 33+
+  final bool listenToBroadcastsFromOtherApps;
+
   StreamSubscription? _subscription;
 
   /// Creates a new [BroadcastReceiver], which subscribes to the given [names].
   ///
   /// At least one name needs to be provided.
-  BroadcastReceiver({required this.names})
+  BroadcastReceiver({
+    required this.names,
+    this.listenToBroadcastsFromOtherApps = true,
+  })
       : assert(names.length > 0),
         _id = ++_index;
 
@@ -63,6 +71,7 @@ class BroadcastReceiver {
   Map<String, dynamic> toMap() => <String, dynamic>{
         'id': _id,
         'names': names,
+        'listenToBroadcastsFromOtherApps': listenToBroadcastsFromOtherApps,
       };
 
   @override
@@ -74,6 +83,7 @@ class BroadcastReceiver {
   int get hashCode =>
       _id.hashCode ^
       names.hashCode ^
+      listenToBroadcastsFromOtherApps.hashCode ^
       _subscription.hashCode ^
       _messages.hashCode;
 
@@ -83,6 +93,7 @@ class BroadcastReceiver {
         other is BroadcastReceiver &&
             other._id == _id &&
             other.names == names &&
+            other.listenToBroadcastsFromOtherApps == listenToBroadcastsFromOtherApps &&
             other._messages == _messages &&
             other._subscription == _subscription;
   }


### PR DESCRIPTION
Added new name parameter for BroadcastReceiver.new:
**listenToBroadcastsFromOtherApps** _(**true** by default)_
Works for devices with Android 13+. 
Represents **RECEIVER_EXPORTED** if **true** and **RECEIVER_NOT_EXPORTED** if **false**
Fixes a security issue for SDK 34+